### PR TITLE
add support for arbitrary headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The following command line options are supported by checkprovider:
 <dd>Suppress the display of header at the top of the list of timing results.</dd>
 
 <dt>-H header|--header header</dt>
-<dd>Specify an addition HTTP request header. Note: this option can be specified multiple times to provide multiple request headers.</dd>
+<dd>Specify an additional HTTP request header. Note: this option can be specified multiple times to provide multiple request headers.</dd>
 
 <dt>-?|--help</dt>
 <dd>Display full help information.</dd>

--- a/README.md
+++ b/README.md
@@ -124,6 +124,9 @@ The following command line options are supported by checkprovider:
 <dt>-h|--no-header</dt>
 <dd>Suppress the display of header at the top of the list of timing results.</dd>
 
+<dt>-H header|--header header</dt>
+<dd>Specify an addition HTTP request header. Note: this option can be specified multiple times to provide multiple request headers.</dd>
+
 <dt>-?|--help</dt>
 <dd>Display full help information.</dd>
 

--- a/checkprovider
+++ b/checkprovider
@@ -104,6 +104,7 @@ my $inputurl      = undef;    #
 my $usernotice    = undef;
 my $httphost      = undef;    # the HTTP header Host:
 my $hostip        = undef;    # ip address
+my @headers       = ();       # additional request headers
 
 pod2usage( { -verbose => 2 } ) if ( $#ARGV < 0 );
 
@@ -127,7 +128,8 @@ GetOptions(
     'd+'            => \$debug,
     'url|u=s'       => \$inputurl,
     'useragent|U=s' => \$UA,
-    'help|?'        => \$help
+    'help|?'        => \$help,
+    'header|H=s'    => \@headers
 ) or pod2usage;
 
 if ( $#ARGV >= 0 ) {
@@ -265,6 +267,7 @@ sub time_request($) {
         push @request, sprintf("User-Agent: $UA");
     }
     push @request, sprintf("Connection: close");
+    push @request, @headers;
     my $request = join EOL, @request, '', '';
     if ($debug) {
         print "$request";
@@ -679,6 +682,11 @@ Specify the User-Agent HTTP header.
 =item checkprovider "https://example.org/"
 
 Sends the request to example.org over port 443 (since the URI scheme is https). 
+
+
+=item checkprovider -H "Accept-Encoding: gzip, deflate" "https://example.org/"
+
+Sends the request to example.org over port 443 with the "Accept-Encoding: gzip, deflate" request header.
 
 
 =item checkprovider -r 20 -p 5 "https://example.org/search?q=beer"


### PR DESCRIPTION
@yahoo/searchedge @paranoid adding a -H|--header option for things like "accept-encoding: gzip"
