### PR TITLE
add ability to expand query string

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,10 @@ was obtained, or the initial connection was unsuccessful then all fields from
 
 checkprovider will die with an error if the initial DNS lookup or socket creation fail.
 
+## Term
+
+This column shows the query term used for the request.
+
 ## Example
 
 Here is an example of the output:
@@ -96,11 +100,14 @@ The following core modules are also required:
  * Socket
  * Time::HiRes
 
+The folloring modules are optional:
+ * URI::Encode (Note: only used for `-T` option)
+
 # Installation
 
 For now this code is not packaged (see also TODO). To use you install the dependencies and then fetch this repo. For example on redhat-based systems:
 
-    $ sudo yum install perl-IO-Socket-SSL
+    $ sudo yum install perl-IO-Socket-SSL perl-URI-Encode
     $ git clone -o upstream git@github.com:yahoo/checkprovider.git
     $ export PATH=$PATH:`pwd`/checkprovider
 
@@ -136,11 +143,14 @@ The following command line options are supported by checkprovider:
 <dt>-r rate|--rate rate</dt>
 <dd>This specifies the integer rate of requests per second that should be made by checkprovider. The rate and period determine the number of requests sent to the HTTP server. The default rate is 1 request per second.</dd>
 
-<dt>-Q|--query rate</dt>
+<dt>-Q|--query string</dt>
 <dd>The query part of the URL, eg. `-q "q=london"`.</dd>
 
 <dt>-q|--quiet</dt>
 <dd>Suppress the blank line at the end of the results as well as the header. This has the same effect as using `--no-header` and `--no-blank`.</dd>
+
+<dt>-T|--termsfile filename</dt>
+<dd>A file containing a list of terms to be used in place of the `[TERM]` string in the URL. The format of the file is one term per line.</dd>
 
 <dt>-v|--version</dt>
 <dd>Display the version information then quit.</dd>

--- a/checkprovider
+++ b/checkprovider
@@ -277,7 +277,9 @@ sub time_request($) {
         if ( defined $termsfile && $query =~ m/(\[TERM\])/ ) {
             my $term = $terms[$position];
             # try to encode the term if URI::Encode is available
-            eval "use URI::Encode; $term = (URI::Encode->new( { encode_reserved => 0 } ))->encode($terms[$position]); 1";
+            if ( eval "use URI::Encode; 1" ) {
+                $term = (URI::Encode->new( { encode_reserved => 0 } ))->encode($terms[$position]);
+            }
             $query =~ s/\[TERM\]/$term/g;
             $stats{term} = $term;
         }

--- a/checkprovider
+++ b/checkprovider
@@ -162,7 +162,7 @@ if ( defined $inputurl ) {
 # read query terms from a file store in @terms array
 if ( defined $termsfile ) {
     if ( -f $termsfile ) {
-        open my $fh, '<', $termsfile or die "cannot open file: $termsfile";
+        open my $fh, '<:encoding(UTF-8)', $termsfile or die "cannot open file: $termsfile";
         chomp(@terms = <$fh>);
         close $fh;
     } else {
@@ -278,7 +278,7 @@ sub time_request($) {
             my $term = $terms[$position];
             # try to encode the term if URI::Encode is available
             if ( eval "use URI::Encode; 1" ) {
-                $term = (URI::Encode->new( { encode_reserved => 0 } ))->encode($terms[$position]);
+                $term = (URI::Encode->new( { encode_reserved => 1 } ))->encode($terms[$position]);
             }
             $query =~ s/\[TERM\]/$term/g;
             $stats{term} = $term;

--- a/checkprovider
+++ b/checkprovider
@@ -95,7 +95,7 @@ my $rate          = RATE;     # the rate of requests
 my $period        = PERIOD;   # the period of the requests
 my $feed          = "/";      # the feed
 my $query         = "";       # the query part
-my $queryterm     = undef;    # the query term if any
+my $termsfile     = undef;    # the query term list in a file
 my $port          = PORT;     # the port number for the above hostname
 my $frequency     = undef;    # the frequency of the queries
 my $debug         = 0;        # no debugging
@@ -105,6 +105,8 @@ my $usernotice    = undef;
 my $httphost      = undef;    # the HTTP header Host:
 my $hostip        = undef;    # ip address
 my @headers       = ();       # additional request headers
+my @terms         = ();       # list of terms to replace in the query string
+my $position      = 0;        # used to keep track of which term is being used
 
 pod2usage( { -verbose => 2 } ) if ( $#ARGV < 0 );
 
@@ -120,7 +122,7 @@ GetOptions(
     'period|p=i'    => \$period,
     'feed|F=s'      => \$feed,
     'query|Q=s'     => \$query,
-    'queryterm|T=s' => \$queryterm,
+    'termsfile|T=s' => \$termsfile,
     'host|w=s'      => \$httphost,
     'wip=s'         => \$hostip,
     'port=s'        => \$port,
@@ -157,6 +159,18 @@ if ( defined $inputurl ) {
     }
 }
 
+# read query terms from a file store in @terms array
+if ( defined $termsfile ) {
+    if ( -f $termsfile ) {
+        open my $fh, '<', $termsfile or die "cannot open file: $termsfile";
+        chomp(@terms = <$fh>);
+        close $fh;
+    } else {
+        print "FATAL: cannot find file: $termsfile\n";
+        exit(1);
+    }
+}
+
 if ( $hostip =~ m/([^:]*):(\d*)/ ) {
     $hostip = $1;
     $port   = $2;
@@ -190,6 +204,13 @@ for ( my $test = 0 ; !$period || $test < $total ; $total && $test++ ) {
     # if we are the parent process then we should commence a non-blocking wait
     # for child processes
     if ($pid) {
+
+        # advance the term list position for the next child
+        if ( ($position + 1) > $#terms ) {
+            $position = 0;
+        } else {
+            $position = $position + 1;
+        }
 
         # sleep to set the required request rate
         ( defined $frequency ) and sleep $frequency
@@ -252,6 +273,14 @@ sub time_request($) {
         push @request, sprintf( "GET %s HTTP/1.1", $feed );
     }
     else {
+        # replace query term and save off term in stats hash
+        if ( defined $termsfile && $query =~ m/(\[TERM\])/ ) {
+            my $term = $terms[$position];
+            # try to encode the term if URI::Encode is available
+            eval "use URI::Encode; $term = (URI::Encode->new( { encode_reserved => 0 } ))->encode($terms[$position]); 1";
+            $query =~ s/\[TERM\]/$term/g;
+            $stats{term} = $term;
+        }
         push @request, sprintf( "GET %s?%s HTTP/1.1", $feed, $query );
     }
     push @request,
@@ -406,7 +435,8 @@ sub show_header() {
     $units = sprintf( "%s%s", ' ' x ( $length + $indent ), $units );
 
     # generate the complete header
-    print "$units\n$time $times  Bytes Status\n";
+    my $termsheader = ( defined $termsfile ) ? "   [Term]" : "";
+    print "$units\n$time $times  Bytes Status$termsheader\n";
 }    # show_header()
 
 # show_response($)
@@ -431,6 +461,7 @@ sub show_response($) {
     #     - total time
     #     - bytes
     #     - status
+    #     - term
     # if the connect failed, then all other values will be undefined
     $stats->{$_} =
       ( defined $stats->{$_} )
@@ -474,6 +505,9 @@ sub show_response($) {
         print "  ";
         print join( " ", map { $stats->{$_} } qw( bytes error ) );
         print " (" . $stats->{status} . ")";
+        if ( defined $stats->{term} ) {
+            print " [" . $stats->{term} . "]";
+        }
     }
     else {
         print strftime( "%s ", localtime( int $stats->{time} ) );
@@ -692,6 +726,11 @@ Sends the request to example.org over port 443 with the "Accept-Encoding: gzip, 
 =item checkprovider -r 20 -p 5 "https://example.org/search?q=beer"
 
 Sends the request to example.org over port 443 sending at a rate of 20 qps for a duration of 5 seconds.
+
+
+=item checkprovider -T termlist "https://example.org/search?p=[TERM]"
+
+Iterate through the lines in file termlist and replace [TERM] with the line before sending the request.
 
 
 =back


### PR DESCRIPTION
@nilnilnil @yahoo/searchedge @paranoid 

This adds the ability to have search terms in a file and loop through it expanding the string "[TERM]" in the URL. This way you can do something like:

> $ cat termsfile
> beer
> soda
> red wine
> $ checkprovider -T termsfile https://search.yahoo.com/search?p=[TERM]

If URI::Encode is available the terms in termsfile will be percent-encoded, otherwise they are expected to be encoded in the file.
